### PR TITLE
Implemented prometheus datasource w/ auto porting

### DIFF
--- a/client/Components/Dashboard/ClusterView/StreamingNetworkPressure.jsx
+++ b/client/Components/Dashboard/ClusterView/StreamingNetworkPressure.jsx
@@ -17,7 +17,7 @@ const StreamingNetworkPressure = () => {
   const [chartData, setChartData] = useState({});
 
   async function chart() {
-    const data = await fetchChartData('freeMemory', 6, '5m')
+    const data = await fetchChartData('networkTransmitted', 6, '5m')
     setChartData(data);
   }
 

--- a/server/controller/podController.js
+++ b/server/controller/podController.js
@@ -7,7 +7,7 @@ const podController = {};
 
 podController.getPodsRaw = async function(req, res, next){
   console.log('in the podController');
-  const data = (await k8sApi.listNamespacedPod('default')).response.body.items;
+  const data = (await k8sApi.listPodForAllNamespaces()).response.body.items;
   console.log(data);
   res.locals.pods = data;
   return next();

--- a/server/datasources/dataSources.js
+++ b/server/datasources/dataSources.js
@@ -1,7 +1,11 @@
 const PrometheusAPI = require("./prometheusAPI");
 
+const memory = {
+  isPrometheusUp: { check: false },
+} 
+
 module.exports = () => {
   return {
-    prometheusAPI: new PrometheusAPI(),
+    prometheusAPI: new PrometheusAPI(memory),
   }
 }

--- a/server/datasources/prometheusAPI.js
+++ b/server/datasources/prometheusAPI.js
@@ -97,7 +97,7 @@ class PrometheusAPI extends RESTDataSource{
 
   async getNetworkTransmitBytes(startDateTime, endDateTime, step){
     // if(!this.prometheusCheck()) return console.log('DEAD')
-    let query = `query_range?query=sum(rate(node_network_transmit_bytes[2m]))`;
+    let query = `query_range?query=sum(rate(node_network_transmit_bytes_total[2m]))`;
     query += `&start=${startDateTime}&end=${endDateTime}&step=${step}`;
     const data = await this.get(query).then(({ data }) => data.result).catch(err => console.log(err));
 

--- a/server/datasources/prometheusAPI.js
+++ b/server/datasources/prometheusAPI.js
@@ -1,6 +1,5 @@
 const { spawn } = require('child_process')
 const {RESTDataSource} = require('apollo-datasource-rest');
-// docs: https://www.apollographql.com/docs/apollo-server/data/data-sources/
 
 const prometheusURL = 'http://127.0.0.1:9090/api/v1/';
 
@@ -40,9 +39,9 @@ class PrometheusAPI extends RESTDataSource{
   //http://localhost:9090/api/v1/query_range?query=sum(rate(node_network_transmit_bytes[…]2021-05-26T20:55:06.753Z&end=2021-05-28T20:55:05.208Z&step=1m
 
   async getNetworkTransmitBytes(startDateTime, endDateTime, step){
-    const checkVar = await this.portPrometheus()
-    console.log('checkVar:',checkVar)
-    if(!checkVar) return console.log('DEAD') 
+    const checkProm = await this.portPrometheus()
+    
+    if(!checkProm) return console.log('Error with Pometheus Configurations'); 
     let query = `query_range?query=sum(rate(node_network_transmit_bytes_total[2m]))`;
     query += `&start=${startDateTime}&end=${endDateTime}&step=${step}`;
     const data = await this.get(query).then(({ data }) => data.result).catch(err => console.log(err));
@@ -106,7 +105,7 @@ class PrometheusAPI extends RESTDataSource{
       })
 
       process.on('close', (code) => {
-        if(code === 1) resolve(true)
+        if(code === 1) resolve(this.isPrometheusUp.check)
         else {
           console.log(`child process exited with code ${code}`);
           this.isPrometheusUp.check = false;

--- a/server/datasources/prometheusAPI.js
+++ b/server/datasources/prometheusAPI.js
@@ -1,82 +1,24 @@
-
 const { spawn } = require('child_process')
 const {RESTDataSource} = require('apollo-datasource-rest');
 // docs: https://www.apollographql.com/docs/apollo-server/data/data-sources/
 
 const prometheusURL = 'http://127.0.0.1:9090/api/v1/';
 
-
-// let portAttempts = 0;
-// let isPrometheusUp = false;
-
-// function portPrometheus(port = 9090){
-//   if(!/^\d+$/.test(port)) return console.log(`ERROR: ${port} not a valid port number`);
-//   console.log('here');
-//   try{
-//     const process = spawn('kubectl --namespace=default port-forward deploy/prometheus-server',[port])
-//     portAttempts += 1
-  
-//     console.log('there');
-//     // console.log(process);
-
-//     process.stdout.on('data', (data) => {
-//       console.log(`stdout: ${data}`);
-//       isPrometheusUp = true;
-//     })
-
-//     process.stderr.on('data', (err) => {
-//       console.log(`stderr: ${err}`);
-//     })
-
-//     process.on('close', (code) => {
-//       if(code === 1) console.log(`Port ${port} is already in use. Try running the query again. 
-//                                   If the error persists, kill port 9090 before trying again`);
-//       else console.log(`child process exited with code ${code}`);
-//     })
-//     console.log('howdy');
-
-//     setTimeout(() => {
-//       console.log('sleep')
-//       prometheusCheck()
-//       console.log('evades');
-//     }, 1000);
-
-//     console.log('lol node is cool n cruel');
-
-//   }catch(err){
-//     console.log(err);
-//   }
-// }
-
-// async function prometheusCheck(){
-//   console.log('meeep');
-//   if (isPrometheusUp) return true;
-//   if (portAttempts > 3) return false;
-//   let queryStr = prometheusURL +'query?query=up';
-//   try{
-//     const response = await fetch(queryStr)
-//     const check = await response.json(); // this line may be unnecessary
-//     isPrometheusUp = true;
-//     return true;
-//   }catch(err){
-//     console.log('error connecting to prometheus, trying to Port Forward on 9090...');
-//     portPrometheus();
-//   } 
-// } 
-
-
-
 class PrometheusAPI extends RESTDataSource{
-  constructor(){
+  
+  constructor({ isPrometheusUp }){
     super()
     this.baseURL = prometheusURL;
     this.portAttempts = 0;
-    this.isPrometheusUp = false;
-
+    this.isPrometheusUp = isPrometheusUp;
+    this.portPrometheus = this.portPrometheus.bind(this);
   }
 
   async getCpuUsageSecondsRateByName(startDateTime, endDateTime, step){
-    // if(!this.prometheusCheck()) return console.log('DEAD')
+    const checkVar = await this.portPrometheus()
+    console.log('checkVar:',checkVar)
+    if(!checkVar) return console.log('DEAD') 
+    console.log('when does this run?')
     let query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{container_name!="POD",namespace!=""}[2m])) by (namespace)`;
     query += `&start=${startDateTime}&end=${endDateTime}&step=${step}`;
     const data = await this.get(query).then( ({ data }) => data.result);
@@ -85,7 +27,9 @@ class PrometheusAPI extends RESTDataSource{
   }
 
   async getClusterFreeMemory(startDateTime, endDateTime, step){
-    // if(!this.prometheusCheck()) return console.log('DEAD')
+    const checkVar = await this.portPrometheus()
+    console.log('checkVar:',checkVar)
+    if(!checkVar) return console.log('DEAD') 
     let query = `query_range?query=sum(rate(node_memory_MemFree_bytes[2m]))`;
     query += `&start=${startDateTime}&end=${endDateTime}&step=${step}`;
     const data = await this.get(query).then(({ data }) => data.result);
@@ -96,7 +40,9 @@ class PrometheusAPI extends RESTDataSource{
   //http://localhost:9090/api/v1/query_range?query=sum(rate(node_network_transmit_bytes[…]2021-05-26T20:55:06.753Z&end=2021-05-28T20:55:05.208Z&step=1m
 
   async getNetworkTransmitBytes(startDateTime, endDateTime, step){
-    // if(!this.prometheusCheck()) return console.log('DEAD')
+    const checkVar = await this.portPrometheus()
+    console.log('checkVar:',checkVar)
+    if(!checkVar) return console.log('DEAD') 
     let query = `query_range?query=sum(rate(node_network_transmit_bytes_total[2m]))`;
     query += `&start=${startDateTime}&end=${endDateTime}&step=${step}`;
     const data = await this.get(query).then(({ data }) => data.result).catch(err => console.log(err));
@@ -141,61 +87,36 @@ class PrometheusAPI extends RESTDataSource{
     }
   }
 
-  portPrometheus(){
-  // if(!/^\d+$/.test(port)) return console.log(`ERROR: ${port} not a valid port number`);
-  console.log('here');
-  try{
-    const process = spawn('kubectl --namespace=default port-forward deploy/prometheus-server 9090')
-    this.portAttempts += 1
-  
-    console.log('there');
-    // console.log(process);
+  portPrometheus = () => new Promise((resolve, reject) => {
 
-    process.stdout.on('data', (data) => {
-      console.log(`stdout: ${data}`);
-      this.isPrometheusUp = true;
-    })
+    if(this.isPrometheusUp.check) resolve(true);
+    
+    try{
+      const process = spawn('kubectl', ['--namespace=prometheus', 'port-forward', 'deploy/prometheus-server', '9090'])
+      this.portAttempts += 1
 
-    process.stderr.on('data', (err) => {
-      console.log(`stderr: ${err}`);
-    })
+      process.stdout.on('data', (data) => {
+        console.log(`stdout: ${data}`);
+        this.isPrometheusUp.check = true;
+        resolve(true)
+      })
 
-    process.on('close', (code) => {
-      if(code === 1) console.log(`Port ${port} is already in use. Try running the query again. 
-                                  If the error persists, kill port 9090 before trying again`);
-      else console.log(`child process exited with code ${code}`);
-    })
-    console.log('howdy');
+      process.stderr.on('data', async (err) => {
+        // console.log(`stderr: ${err}`);
+      })
 
-    setTimeout(() => {
-      console.log('sleep')
-      this.prometheusCheck()
-      console.log('evades');
-    }, 1000);
+      process.on('close', (code) => {
+        if(code === 1) resolve(true)
+        else {
+          console.log(`child process exited with code ${code}`);
+          this.isPrometheusUp.check = false;
+        }
+      })
+    }catch(err){
+      console.log(err);
+    }
 
-    console.log('lol node is cool n cruel');
-
-  }catch(err){
-    console.log(err);
-  }
-}
-
-async prometheusCheck(){
-  console.log('meeep');
-  if (this.isPrometheusUp) return true;
-  // if (this.portAttempts > 3) return false;
-  let queryStr = this.baseURL +'query?query=up';
-  try{
-    const response = await fetch(queryStr)
-    const check = await response.json(); // this line may be unnecessary
-    this.sPrometheusUp = true;
-    return true;
-  }catch(err){
-    console.log('error connecting to prometheus, trying to Port Forward on 9090...');
-    return this.portPrometheus();
-  } 
-} 
-
+  });
 }
 
 module.exports = PrometheusAPI;

--- a/server/graphQL/resolvers/resolvers.js
+++ b/server/graphQL/resolvers/resolvers.js
@@ -42,7 +42,7 @@ module.exports = {
   Query: {
     getPods: async (parent, args, context, info) => {
       /** NEW CODE  */
-      const podsApi = (await k8sApi.listNamespacedPod('default')).response.body.items;
+      const podsApi = (await k8sApi.listPodForAllNamespaces()).response.body.items;
       const podsCmd = (await podData.getMetrics()).items
 
       //Brute force approach to merging these two datasources by cycling through to match on pod name and  container name
@@ -51,6 +51,7 @@ module.exports = {
         // question though - how closely do we want to match original data source? This could allow us to build a graphQL tool
         // maybe use a lodash function https://lodash.com/docs/4.17.15; this will likely have a similar time complexity,
         // but it will be more declarative and easier to read.
+
       const podArray = []
       podsApi.forEach((pod) => {
         const mergedPod = podsCmd.reduce((original, metrics) => {


### PR DESCRIPTION
The Datasources now has an object that holds the port state in a persistent memory object. That object is passed to all instances of the Prometheus datasource class. 

This memory stores an object with a check property initialized to false.

Whenever a port is successfully deployed the "check" flag is set to true; if the child process stream closes, for any reason other than "already in use" (status code 1) then we set it to false. This is because concurrent calls of the function will result in an exit code 1 after the first process opens a port.

In the future, this flag will be checked before porting and instant resolve the promise w/ true and move on in the process.